### PR TITLE
reposition LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OBJS := src/main.o src/stlink.o src/crypto.o tiny-AES-c/aes.o
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 stlink-tool: $(OBJS)
-	$(CC) $(LDFLAGS) $(OBJS) -o $@
+	$(CC) $(OBJS) $(LDFLAGS) -o $@
 
 clean:
 	rm -f src/*.o


### PR DESCRIPTION
objects linked should be called before flags. this solves a bunch of undefined reference errors on ubuntu systems. more info: http://billauer.co.il/blog/2017/04/gcc-ld-link-debian/